### PR TITLE
Add LibraryName to Types, Properties, Parameters, Add SecuritySchemes from Libraries ...

### DIFF
--- a/source/Raml.Parser/Builders/RamlBuilder.cs
+++ b/source/Raml.Parser/Builders/RamlBuilder.cs
@@ -17,7 +17,10 @@ namespace Raml.Parser.Builders
 			var doc = new RamlDocument(dynamicRaml);
             doc.Types = new RamlTypesOrderedDictionary();
 
-		    if (dynamicRaml.ContainsKey("uses"))
+            var securitySchemes = Enumerable.Empty<IDictionary<string, SecurityScheme>>();
+            var traits = Enumerable.Empty<IDictionary<string, Method>>();
+
+            if (dynamicRaml.ContainsKey("uses"))
 		    {
 		        var uses = dynamicRaml["uses"] as object[];
 		        if (uses != null)
@@ -35,8 +38,12 @@ namespace Raml.Parser.Builders
 
                             var preffix = (string)lib["key"];
 		                    var dynamic = await RamlParser.GetDynamicStructure(filePath);
+                            
 		                    TypeBuilder.AddTypes(doc.Types, (IDictionary<string, object>) dynamic, preffix);
-		                }
+                            var mediaType = ((IDictionary<string, object>)dynamic).ContainsKey("mediaType") ? (string)dynamicRaml["mediaType"] : null;
+                            securitySchemes = GetSecuritySchemes((IDictionary<string, object>)dynamic, mediaType).Union(securitySchemes);
+                            traits = GetTraits((IDictionary<string, object>)dynamic, mediaType).Union(traits);
+                        }
 		            }
 		        }
 		    }
@@ -50,9 +57,9 @@ namespace Raml.Parser.Builders
 			doc.SecuredBy = GetSecuredBy(dynamicRaml);
 			doc.Method = dynamicRaml.ContainsKey("method") ? (string)dynamicRaml["method"] : null;
 			doc.Protocols = ProtocolsBuilder.Get(dynamicRaml);
-			doc.SecuritySchemes = GetSecuritySchemes(dynamicRaml, doc.MediaType);
+			doc.SecuritySchemes = GetSecuritySchemes(dynamicRaml, doc.MediaType).Union(securitySchemes);
 			doc.ResourceTypes = GetResourceTypes(dynamicRaml, doc.MediaType);
-			doc.Traits = GetTraits(dynamicRaml, doc.MediaType);
+			doc.Traits = GetTraits(dynamicRaml, doc.MediaType).Union(traits);
 			doc.Schemas = GetSchemas(dynamicRaml);
 			doc.Resources = GetResources(dynamicRaml, doc.ResourceTypes, doc.Traits, doc.MediaType);
 		    

--- a/source/Raml.Parser/Builders/SecuritySchemeDescriptorBuilder.cs
+++ b/source/Raml.Parser/Builders/SecuritySchemeDescriptorBuilder.cs
@@ -17,12 +17,13 @@ namespace Raml.Parser.Builders
 			if (dynamicRaml.ContainsKey("queryParameters"))
 				descriptor.QueryParameters = new ParametersBuilder((IDictionary<string, object>)dynamicRaml["queryParameters"]).GetAsDictionary();
 
-            var responsesNest = ((object[])dynamicRaml["responses"]).ToList().Cast<ExpandoObject>() ;
-            var responses = responsesNest.ToDictionary(k => ((IDictionary<string, object>)k)["code"].ToString(), v => (object)v);
 
             if (dynamicRaml.ContainsKey("responses"))
+            {
+                var responsesNest = ((object[])dynamicRaml["responses"]).ToList().Cast<ExpandoObject>();
+                var responses = responsesNest.ToDictionary(k => ((IDictionary<string, object>)k)["code"].ToString(), v => (object)v);
                 descriptor.Responses = new ResponsesBuilder(responses).GetAsDictionary(defaultMediaType);
-
+            }
 			return descriptor;
 		}
 	}

--- a/source/Raml.Parser/Builders/SecuritySchemeDescriptorBuilder.cs
+++ b/source/Raml.Parser/Builders/SecuritySchemeDescriptorBuilder.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
 using Raml.Parser.Expressions;
 
 namespace Raml.Parser.Builders
@@ -15,8 +17,11 @@ namespace Raml.Parser.Builders
 			if (dynamicRaml.ContainsKey("queryParameters"))
 				descriptor.QueryParameters = new ParametersBuilder((IDictionary<string, object>)dynamicRaml["queryParameters"]).GetAsDictionary();
 
-			if (dynamicRaml.ContainsKey("responses"))
-                descriptor.Responses = new ResponsesBuilder((IDictionary<string, object>)dynamicRaml["responses"]).GetAsDictionary(defaultMediaType);
+            var responsesNest = ((object[])dynamicRaml["responses"]).ToList().Cast<ExpandoObject>() ;
+            var responses = responsesNest.ToDictionary(k => ((IDictionary<string, object>)k)["code"].ToString(), v => (object)v);
+
+            if (dynamicRaml.ContainsKey("responses"))
+                descriptor.Responses = new ResponsesBuilder(responses).GetAsDictionary(defaultMediaType);
 
 			return descriptor;
 		}

--- a/source/Raml.Parser/Builders/TypeBuilder.cs
+++ b/source/Raml.Parser/Builders/TypeBuilder.cs
@@ -28,10 +28,16 @@ namespace Raml.Parser.Builders
                     var dic = dynamicType as IDictionary<string, object>;
                     foreach (var kv in dic)
                     {
+                        var type = GetRamlType(kv);
                         var key = kv.Key;
+                        
                         if (preffix != null)
+                        {
+                            type.Namespace = preffix;
                             key = preffix + "." + key;
-                        ramlTypes.Add(key, GetRamlType(kv));
+                        }
+                        
+                        ramlTypes.Add(key, type);
                     }
                 }
                 ParseDefferredTypes();
@@ -44,10 +50,13 @@ namespace Raml.Parser.Builders
 
             foreach (var type in types)
             {
+                var ramlType = GetRamlType(type);
+                ramlType.Namespace = preffix;
+
                 var key = type.Key;
-                if (preffix != null)
-                    key = preffix + "." + key;
-                ramlTypes.Add(key, GetRamlType(type));
+                if (ramlType.Namespace != null)
+                    key = ramlType.Namespace + "." + key;
+                ramlTypes.Add(key, ramlType);
 
             }
 
@@ -149,6 +158,8 @@ namespace Raml.Parser.Builders
 
             return preffix + "." + extractedType;
         }
+
+
 
         private static IDictionary<string, object> GetOtherProperties(IDictionary<string, object> value)
         {

--- a/source/Raml.Parser/Builders/TypeBuilder.cs
+++ b/source/Raml.Parser/Builders/TypeBuilder.cs
@@ -33,7 +33,7 @@ namespace Raml.Parser.Builders
                         
                         if (preffix != null)
                         {
-                            type.Namespace = preffix;
+                            type.LibraryName = preffix;
                             key = preffix + "." + key;
                         }
                         
@@ -51,11 +51,11 @@ namespace Raml.Parser.Builders
             foreach (var type in types)
             {
                 var ramlType = GetRamlType(type);
-                ramlType.Namespace = preffix;
+                ramlType.LibraryName = preffix;
 
                 var key = type.Key;
-                if (ramlType.Namespace != null)
-                    key = ramlType.Namespace + "." + key;
+                if (ramlType.LibraryName != null)
+                    key = ramlType.LibraryName + "." + key;
                 ramlTypes.Add(key, ramlType);
 
             }

--- a/source/Raml.Parser/Expressions/Parameter.cs
+++ b/source/Raml.Parser/Expressions/Parameter.cs
@@ -12,7 +12,7 @@ namespace Raml.Parser.Expressions
 		public string Type { get; set; }
 		public bool Required { get; set; }
 		public string DisplayName { get; set; }
-        public string Namespace { get; set; }
+        public string LibraryName { get; set; }
 		public string Description { get; set; }
 		public IEnumerable<string> Enum { get; set; }
 		public bool Repeat { get; set; }

--- a/source/Raml.Parser/Expressions/Parameter.cs
+++ b/source/Raml.Parser/Expressions/Parameter.cs
@@ -12,6 +12,7 @@ namespace Raml.Parser.Expressions
 		public string Type { get; set; }
 		public bool Required { get; set; }
 		public string DisplayName { get; set; }
+        public string Namespace { get; set; }
 		public string Description { get; set; }
 		public IEnumerable<string> Enum { get; set; }
 		public bool Repeat { get; set; }

--- a/source/Raml.Parser/Expressions/Property.cs
+++ b/source/Raml.Parser/Expressions/Property.cs
@@ -14,18 +14,18 @@ namespace Raml.Parser.Expressions
         // file
         public ICollection<string> FileTypes { get; set; }
 
-        private string _namespace;
-        public new string Namespace
+        private string _libraryName;
+        public new string LibraryName
         {
             get
             {
-                if (_namespace == null && !string.IsNullOrEmpty(Type) && Type.Contains("."))
-                    _namespace = Type.Remove(Type.LastIndexOf(".", StringComparison.Ordinal));
-                return _namespace;
+                if (_libraryName == null && !string.IsNullOrEmpty(Type) && Type.Contains("."))
+                    _libraryName = Type.Remove(Type.LastIndexOf(".", StringComparison.Ordinal));
+                return _libraryName;
             }
             set
             {
-                _namespace = value;
+                _libraryName = value;
             }
         }
     }

--- a/source/Raml.Parser/Expressions/Property.cs
+++ b/source/Raml.Parser/Expressions/Property.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Raml.Parser.Expressions
 {
@@ -12,5 +13,20 @@ namespace Raml.Parser.Expressions
 
         // file
         public ICollection<string> FileTypes { get; set; }
+
+        private string _namespace;
+        public new string Namespace
+        {
+            get
+            {
+                if (_namespace == null && !string.IsNullOrEmpty(Type) && Type.Contains("."))
+                    _namespace = Type.Remove(Type.LastIndexOf(".", StringComparison.Ordinal));
+                return _namespace;
+            }
+            set
+            {
+                _namespace = value;
+            }
+        }
     }
 }

--- a/source/Raml.Parser/Expressions/RamlType.cs
+++ b/source/Raml.Parser/Expressions/RamlType.cs
@@ -19,7 +19,7 @@ namespace Raml.Parser.Expressions
 
         public string DisplayName { get; set; }
 
-        public string Namespace { get; set; }
+        public string LibraryName { get; set; }
 
         public string Description { get; set; }
 

--- a/source/Raml.Parser/Expressions/RamlType.cs
+++ b/source/Raml.Parser/Expressions/RamlType.cs
@@ -19,6 +19,8 @@ namespace Raml.Parser.Expressions
 
         public string DisplayName { get; set; }
 
+        public string Namespace { get; set; }
+
         public string Description { get; set; }
 
         public bool Required { get; set; }
@@ -31,5 +33,6 @@ namespace Raml.Parser.Expressions
 
         public IDictionary<string, object> Facets { get; set; }
         public IDictionary<string, object> OtherProperties { get; set; }
+
     }
 }


### PR DESCRIPTION
- Added LibraryName to Types, Properties, Parameters, set from library name prefix.
- Fix: SecuritySchemes were not being added from libraries
- Fix: SecurityScheme responses were not being parsed correctly
- Fix: Traits were not being added from libraries